### PR TITLE
fix(vue-app): register class components hooks

### DIFF
--- a/packages/vue-app/lib/entry-server.js
+++ b/packages/vue-app/lib/entry-server.js
@@ -1,6 +1,6 @@
+import { createApp } from './app';
 import Vue from 'vue';
 import App from '@/App.vue';
-import { createApp } from './app';
 import { composeComponentOptions } from './utils';
 
 Vue.prototype.$auth = null;

--- a/packages/vue-app/lib/register-component-hooks.js
+++ b/packages/vue-app/lib/register-component-hooks.js
@@ -1,4 +1,4 @@
-import { Component } from 'vue-property-component';
+import { Component } from 'vue-property-decorator';
 
 Component.registerHooks([
   'asyncData',

--- a/packages/vue-app/lib/register-component-hooks.js
+++ b/packages/vue-app/lib/register-component-hooks.js
@@ -1,4 +1,4 @@
-import Component from 'vue-class-component';
+import { Component } from 'vue-property-component';
 
 Component.registerHooks([
   'asyncData',


### PR DESCRIPTION
# Description
Currently there is an odd behaviour with registered class component hooks. Sometimes it works, sometimes not. By using `vue-property-decorator` instead of `vue-class-components` to register those hooks, should make it work.