### PR TITLE
refactor(vue-app): changed lodash forEach to for of loop and call mixins as function

### DIFF
--- a/packages/vue-app/lib/app.js
+++ b/packages/vue-app/lib/app.js
@@ -6,7 +6,6 @@ import App from '@/App.vue';
 import { createRouter } from './router/';
 import { createStore } from './store/';
 import { sync } from 'vuex-router-sync';
-import forEach from 'lodash/forEach';
 import * as Cookies from 'js-cookie';
 <% if (config.progressbar) { %> 
 import VueProgressBar from 'vue-progressbar';
@@ -68,13 +67,10 @@ export function createApp(ssrContext) {
   Vue.router = router;
 
   const mixinContext = require.context('@/', false, /^\.\/app\.js$/i);
-        
-  forEach(mixinContext.keys(), r => {
-    const Mixin = mixinContext(r).default;
-    if (typeof Mixin !== 'undefined') {
-      const mixin = new Mixin(ssrContext);
-    }
-  });
+  for(const key of mixinContext.keys()) {
+    const mixin = mixinContext(key).default;
+    if(typeof mixin === 'function') mixin(ssrContext);
+  }
     
   const app = new Vue({
     i18n,

--- a/packages/vue-app/lib/entry-client.js
+++ b/packages/vue-app/lib/entry-client.js
@@ -1,7 +1,6 @@
 import { createApp } from './app';
 import Vue from 'vue';
 import axios from 'axios';
-import forEach from 'lodash/forEach';
 import { composeComponentOptions } from './utils';
 const { app, router, store } = createApp({ isServer: false });
 
@@ -41,14 +40,10 @@ class ClientEntry {
 
   initMixin() {
     const mixinContext = require.context('@/', false, /^\.\/entry-client\.js$/i);
-        
-    forEach(mixinContext.keys(), r => {
-      const EntryClientMixin = mixinContext(r).default;
-      if (typeof EntryClientMixin !== 'undefined') {
-        // eslint-disable-next-line no-unused-vars
-        const mixin = new EntryClientMixin();
-      }
-    });
+    for(const key of mixinContext.keys()) {
+      const mixin = mixinContext(key).default;
+      if (typeof mixin === 'function') mixin();
+    }
   }
 
   addMobileCheck() {

--- a/packages/vue-app/lib/entry-server.js
+++ b/packages/vue-app/lib/entry-server.js
@@ -27,12 +27,9 @@ export default async context => {
       throw error;
     }
         
-    for (const r of mixinContext.keys()) {
-      const EntryServerMixin = mixinContext(r).default;
-      if (typeof EntryServerMixin !== 'undefined') {
-        // eslint-disable-next-line no-new
-        new EntryServerMixin(context);
-      }
+    for (const key of mixinContext.keys()) {
+      const mixin = mixinContext(key).default;
+      if (typeof mixin === 'function') mixin(context);
     }
         
     for (const [key] of Object.entries(store._actions)) {


### PR DESCRIPTION
BREAKING CHANGE: exporting classes in entry files is no longer supported because we are not creating an instance anymore. instead we are calling the default export as function.