### PR TITLE
feat: pass whole req object to server entries

### DIFF
--- a/packages/@averjs/builder/lib/builders/ssr.js
+++ b/packages/@averjs/builder/lib/builders/ssr.js
@@ -39,14 +39,10 @@ export default class SsrBuilder extends BaseBuilder {
     const context = {
       title: process.env.APP_NAME,
       url: req.url,
-      cookies: req.cookies,
-      host: req.headers.host
+      req
     };
 
     if (this.config.csrf) Object.assign(context, { csrfToken: req.csrfToken() });
-
-    if (typeof req.flash === 'function') Object.assign(context, { flash: req.flash() });
-    if (typeof req.isAuthenticated === 'function') Object.assign(context, { isAuthenticated: req.isAuthenticated(), user: req.user });
     
     try {
       const html = await this.renderer.renderToString(context);

--- a/packages/@averjs/builder/lib/builders/static.js
+++ b/packages/@averjs/builder/lib/builders/static.js
@@ -34,8 +34,9 @@ export default class StaticBuilder extends BaseBuilder {
       const context = {
         title: process.env.APP_NAME,
         url: route.path,
-        cookies: '',
-        host: ''
+        req: {
+          cookies: []
+        }
       };
 
       if (this.config.csrf) Object.assign(context, { csrfToken: '' });

--- a/packages/@averjs/vue-app/templates/i18n.js
+++ b/packages/@averjs/vue-app/templates/i18n.js
@@ -5,7 +5,7 @@ import merge from 'lodash/merge';
 
 Vue.use(VueI18n);
 
-export function createI18n(ssrContext) {
+export function createI18n({ isServer, context }) {
   let i18nConfig = {
     locale: 'de',
     fallbackLocale: 'de'
@@ -24,8 +24,8 @@ export function createI18n(ssrContext) {
 
   const i18n = new VueI18n(i18nConfig);
 
-  if (!ssrContext.isServer) i18n.locale = Cookies.get('language') || i18nConfig.locale;
-  else i18n.locale = ssrContext.context.cookies.language || i18nConfig.locale;
+  if (!isServer) i18n.locale = Cookies.get('language') || i18nConfig.locale;
+  else i18n.locale = context.req.cookies.language || i18nConfig.locale;
 
   Vue.prototype.$locale = {
     change: (lang) => {


### PR DESCRIPTION
By passing the whole request object from the server to the server entries, the user has more control. For example if there is a server middleware which exposes something over `req` it is now directly passed to the user.

This is a breaking change because projects using the old passed variables to the context are now no longer available, like `isAuthenticated `. The only exception is for `csrfToken`, because it is a aver feature.