### PR TITLE
feat: pass to and from to async data from vue-router

### DIFF
--- a/packages/@averjs/vue-app/templates/entry-client.js
+++ b/packages/@averjs/vue-app/templates/entry-client.js
@@ -27,7 +27,7 @@ class ClientEntry {
         if (!asyncDataHooks.length) return next();
 
         try {
-          await Promise.all(asyncDataHooks.map(hook => hook({ store, route: to, isServer: false })))
+          await Promise.all(asyncDataHooks.map(hook => hook({ store, route: { to, from }, isServer: false })))
           next();
         } catch(err) {
           next(err);
@@ -95,7 +95,7 @@ class ClientEntry {
           try {
             await asyncData({
               store: this.$store,
-              route: to,
+              route: { to, from },
               isServer: false
             });
             next();

--- a/packages/@averjs/vue-app/templates/entry-server.js
+++ b/packages/@averjs/vue-app/templates/entry-server.js
@@ -58,7 +58,10 @@ export default async context => {
       if (typeof asyncData === 'function' && asyncData) {
         await asyncData({
           store,
-          route: router.currentRoute,
+          route: {
+            to: router.currentRoute,
+            from: undefined
+          },
           isServer: true
         });
       }
@@ -68,7 +71,10 @@ export default async context => {
     if (typeof asyncData === 'function' && asyncData) {
       await asyncData({
         store,
-        route: router.currentRoute,
+        route: {
+          to: router.currentRoute,
+          from: undefined
+        },
         isServer: true
       });
     }


### PR DESCRIPTION
BREAKING CHANGE: If you ever used the passed `route` in asyncData, it might break because now a object is passed with `to` and `from`.