### PR TITLE
refactor(plugins): entries should be placed in `entries` folder

### DIFF
--- a/packages/@averjs/core/lib/plugins.js
+++ b/packages/@averjs/core/lib/plugins.js
@@ -86,27 +86,39 @@ export default class PluginContainer {
     const pluginPathDir = this.normalizePluginPath(pluginPath);
     let dirname = pluginPathDir.split('/');
     dirname = dirname[dirname.length - 1];
+    const entriesFolder = path.resolve(pluginPathDir, './entries');
+    let entries = [];
 
-    const appFile = path.resolve(pluginPathDir, './app.js');
-    const clientFile = path.resolve(pluginPathDir, './entry-client.js');
-    const serverFile = path.resolve(pluginPathDir, './entry-server.js');
+    if (fs.existsSync(entriesFolder)) entries = fs.readdirSync(entriesFolder);
 
-    if (fs.existsSync(appFile)) {
+    const appIndex = entries.indexOf('app.js');
+    if (appIndex !== -1) {
       const dst = dirname + '/' + 'app.js';
-      this.config.templates.push({ src: appFile, dst });
+      this.config.templates.push({ src: path.resolve(entriesFolder, './app.js'), dst });
       this.config.entries.app.push('./' + dst);
+      entries.splice(appIndex, 1);
     }
 
-    if (fs.existsSync(clientFile)) {
+    const clientIndex = entries.indexOf('entry-client.js');
+    if (clientIndex !== -1) {
       const dst = dirname + '/' + 'entry-client.js';
-      this.config.templates.push({ src: clientFile, dst });
+      this.config.templates.push({ src: path.resolve(entriesFolder, './entry-client.js'), dst });
       this.config.entries.client.push('./' + dst);
+      entries.splice(clientIndex, 1);
     }
 
-    if (fs.existsSync(serverFile)) {
+    const serverIndex = entries.indexOf('entry-server.js');
+    if (serverIndex !== -1) {
       const dst = dirname + '/' + 'entry-server.js';
-      this.config.templates.push({ src: serverFile, dst });
+      this.config.templates.push({ src: path.resolve(entriesFolder, './entry-server.js'), dst });
       this.config.entries.server.push('./' + dst);
+      entries.splice(serverIndex, 1);
+    }
+
+    // register remaining files inside entries folder
+    for (const e of entries) {
+      const dst = dirname + '/' + e;
+      this.config.templates.push({ src: path.resolve(entriesFolder, `./${e}`), dst });
     }
   }
 

--- a/packages/@averjs/vue-app/templates/app.js
+++ b/packages/@averjs/vue-app/templates/app.js
@@ -55,17 +55,14 @@ export function createApp(ssrContext) {
     <% 
       if(typeof config.entries !== 'undefined' && typeof config.entries.app !== 'undefined') {
         for(const entry of config.entries.app) {
-          print(`require('${entry}')`);
+          print(`require('${entry}'),`);
         }
       }
     %>
   ];
 
   const mixinContext = require.context('@/', false, /^\.\/app\.js$/i);
-  for(const key of mixinContext.keys()) {
-    const mixin = mixinContext(key).default;
-    if(typeof mixin === 'function') mixin({ ...ssrContext, appOptions });
-  }
+  for(const key of mixinContext.keys()) entries.push(mixinContext(key));
 
   for(const entry of entries) {
     const mixin = entry.default;

--- a/packages/@averjs/vue-app/templates/entry-client.js
+++ b/packages/@averjs/vue-app/templates/entry-client.js
@@ -43,17 +43,13 @@ class ClientEntry {
       <% 
         if(typeof config.entries !== 'undefined' && typeof config.entries.client !== 'undefined') {
           for(const entry of config.entries.client) {
-            print(`require('${entry}')`);
+            print(`require('${entry}'),`);
           }
         }
       %>
     ];
-
     const mixinContext = require.context('@/', false, /^\.\/entry-client\.js$/i);
-    for(const key of mixinContext.keys()) {
-      const mixin = mixinContext(key).default;
-      if (typeof mixin === 'function') mixin();
-    }
+    for(const key of mixinContext.keys()) entries.push(mixinContext(key));
 
     for(const entry of entries) {
       const mixin = entry.default;


### PR DESCRIPTION
When resolving plugins and their entry files, they should be placed inside a `entries` folder. This way, it is easier for aver to also move files, which could be imported by an entry file, to the cache directory.