### PR TITLE
feat: support for additional extensions

### DIFF
--- a/packages/@averjs/config/__fixtures__/aver-config.js
+++ b/packages/@averjs/config/__fixtures__/aver-config.js
@@ -1,6 +1,7 @@
 export default {
   progressbar: false,
   webpack: {
+    additionalExtensions: [ 'ts' ],
     css: {
       extract: true
     }

--- a/packages/@averjs/config/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/@averjs/config/__tests__/__snapshots__/index.spec.js.snap
@@ -24,6 +24,9 @@ Object {
   "store": Object {},
   "templates": Array [],
   "webpack": Object {
+    "additionalExtensions": Array [
+      "js",
+    ],
     "alias": Object {
       "@": "/aver",
       "@@": "/",

--- a/packages/@averjs/config/__tests__/index.spec.js
+++ b/packages/@averjs/config/__tests__/index.spec.js
@@ -11,6 +11,12 @@ test('should change progressbar option to false', () => {
   expect(config.webpack.css.extract).toBe(true);
 });
 
+test('should concat array with default values', () => {
+  const config = getAverjsConfig();
+  expect(config.progressbar).toBe(false);
+  expect(config.webpack.additionalExtensions).toEqual([ 'js', 'ts' ]);
+});
+
 test('should match default snapshot config when no config file is present', () => {
   jest.spyOn(process, 'cwd').mockReturnValue('/');
   

--- a/packages/@averjs/config/lib/configs/renderer.js
+++ b/packages/@averjs/config/lib/configs/renderer.js
@@ -2,6 +2,7 @@ import path from 'path';
 
 export default () => ({
   babel: {},
+  additionalExtensions: [ 'js' ],
   transpileDependencies: [],
   postcss: {},
   css: {

--- a/packages/@averjs/config/lib/index.js
+++ b/packages/@averjs/config/lib/index.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import merge from 'lodash/merge';
+import mergeWith from 'lodash/mergeWith';
 import { defaultAverjsConfig, defaultFileName } from './configs';
 
 export function getAverjsConfig() {
@@ -18,5 +18,9 @@ export function getAverjsConfig() {
   config.distDir = './dist';
   config.distPath = path.resolve(config.rootDir, config.distDir);
 
-  return merge(config, userConfig);
+  return mergeWith(config, userConfig, (objValue, srcValue) => {
+    if (Array.isArray(objValue)) {
+      return objValue.concat(srcValue);
+    }
+  });
 }

--- a/packages/@averjs/core/lib/plugins.js
+++ b/packages/@averjs/core/lib/plugins.js
@@ -96,7 +96,7 @@ export default class PluginContainer {
       const dst = dirname + '/' + appEntry;
       this.config.templates.push({ src: path.resolve(entriesFolder, `./${appEntry}`), dst });
       this.config.entries.app.push('./' + dst);
-      entries.splice(appEntry, 1);
+      entries = entries.filter(entry => entry !== appEntry);
     }
 
     const clientEntry = this.findEntry('entry-client', entries);
@@ -104,7 +104,7 @@ export default class PluginContainer {
       const dst = dirname + '/' + clientEntry;
       this.config.templates.push({ src: path.resolve(entriesFolder, `./${clientEntry}`), dst });
       this.config.entries.client.push('./' + dst);
-      entries.splice(clientEntry, 1);
+      entries = entries.filter(entry => entry !== clientEntry);
     }
 
     const serverEntry = this.findEntry('entry-server', entries);
@@ -112,7 +112,7 @@ export default class PluginContainer {
       const dst = dirname + '/' + serverEntry;
       this.config.templates.push({ src: path.resolve(entriesFolder, `./${serverEntry}`), dst });
       this.config.entries.server.push('./' + dst);
-      entries.splice(serverEntry, 1);
+      entries = entries.filter(entry => entry !== serverEntry);
     }
 
     // register remaining files inside entries folder

--- a/packages/@averjs/core/lib/plugins.js
+++ b/packages/@averjs/core/lib/plugins.js
@@ -91,28 +91,28 @@ export default class PluginContainer {
 
     if (fs.existsSync(entriesFolder)) entries = fs.readdirSync(entriesFolder);
 
-    const appIndex = entries.indexOf('app.js');
-    if (appIndex !== -1) {
-      const dst = dirname + '/' + 'app.js';
-      this.config.templates.push({ src: path.resolve(entriesFolder, './app.js'), dst });
+    const appEntry = this.findEntry('app', entries);
+    if (typeof appEntry !== 'undefined') {
+      const dst = dirname + '/' + appEntry;
+      this.config.templates.push({ src: path.resolve(entriesFolder, `./${appEntry}`), dst });
       this.config.entries.app.push('./' + dst);
-      entries.splice(appIndex, 1);
+      entries.splice(appEntry, 1);
     }
 
-    const clientIndex = entries.indexOf('entry-client.js');
-    if (clientIndex !== -1) {
-      const dst = dirname + '/' + 'entry-client.js';
-      this.config.templates.push({ src: path.resolve(entriesFolder, './entry-client.js'), dst });
+    const clientEntry = this.findEntry('entry-client', entries);
+    if (typeof clientEntry !== 'undefined') {
+      const dst = dirname + '/' + clientEntry;
+      this.config.templates.push({ src: path.resolve(entriesFolder, `./${clientEntry}`), dst });
       this.config.entries.client.push('./' + dst);
-      entries.splice(clientIndex, 1);
+      entries.splice(clientEntry, 1);
     }
 
-    const serverIndex = entries.indexOf('entry-server.js');
-    if (serverIndex !== -1) {
-      const dst = dirname + '/' + 'entry-server.js';
-      this.config.templates.push({ src: path.resolve(entriesFolder, './entry-server.js'), dst });
+    const serverEntry = this.findEntry('entry-server', entries);
+    if (typeof serverEntry !== 'undefined') {
+      const dst = dirname + '/' + serverEntry;
+      this.config.templates.push({ src: path.resolve(entriesFolder, `./${serverEntry}`), dst });
       this.config.entries.server.push('./' + dst);
-      entries.splice(serverIndex, 1);
+      entries.splice(serverEntry, 1);
     }
 
     // register remaining files inside entries folder
@@ -120,6 +120,11 @@ export default class PluginContainer {
       const dst = dirname + '/' + e;
       this.config.templates.push({ src: path.resolve(entriesFolder, `./${e}`), dst });
     }
+  }
+
+  findEntry(name, entries) {
+    const regex = new RegExp(`${name}\\.(${this.config.webpack.additionalExtensions.join('|')})`, 'i');
+    return entries.find(entry => entry.match(regex));
   }
 
   normalizePluginPath(pluginPath) {

--- a/packages/@averjs/renderer/lib/renderer.js
+++ b/packages/@averjs/renderer/lib/renderer.js
@@ -44,6 +44,7 @@ export default class Renderer {
       const compiled = template(fileToCompile, { interpolate: /<%=([\s\S]+?)%>/g });
       const compiledApp = compiled({
         config: {
+          additionalExtensions: this.config.webpack.additionalExtensions,
           progressbar: this.config.progressbar,
           i18n: this.config.i18n,
           csrf: this.config.csrf,

--- a/packages/@averjs/vue-app/templates/app.js
+++ b/packages/@averjs/vue-app/templates/app.js
@@ -63,7 +63,10 @@ export async function createApp(ssrContext) {
   ];
   let userReturns = {};
 
-  const mixinContext = require.context('@/', false, /^\.\/app\.js$/i);
+  const mixinContext = <%
+    const extensions = config.additionalExtensions.join('|');
+    print(`require.context('@/', false, /^\\.\\/app\\.(${extensions})$/i);`);
+  %>
   for(const key of mixinContext.keys()) entries.push(mixinContext(key));
 
   for(const entry of entries) {

--- a/packages/@averjs/vue-app/templates/entry-client.js
+++ b/packages/@averjs/vue-app/templates/entry-client.js
@@ -49,7 +49,10 @@ import { composeComponentOptions } from './utils';
           }
         %>
       ];
-      const mixinContext = require.context('@/', false, /^\.\/entry-client\.js$/i);
+      const mixinContext = <%
+        const extensions = config.additionalExtensions.join('|');
+        print(`require.context('@/', false, /^\\.\\/entry-client\\.(${extensions})$/i);`);
+      %>
       for(const key of mixinContext.keys()) entries.push(mixinContext(key));
   
       for(const entry of entries) {

--- a/packages/@averjs/vue-app/templates/entry-server.js
+++ b/packages/@averjs/vue-app/templates/entry-server.js
@@ -19,7 +19,10 @@ export default async context => {
         }
       %>
     ];
-    const mixinContext = require.context('@/', false, /^\.\/entry-server\.js$/i);
+    const mixinContext = <%
+      const extensions = config.additionalExtensions.join('|');
+      print(`require.context('@/', false, /^\\.\\/entry-server\\.(${extensions})$/i);`);
+    %>
     for (const key of mixinContext.keys()) entries.push(mixinContext(key));
 
     const renderedFns = [];

--- a/packages/@averjs/vue-app/templates/i18n.js
+++ b/packages/@averjs/vue-app/templates/i18n.js
@@ -13,7 +13,10 @@ export function createI18n({ isServer, context }) {
 
   <% if(typeof config.i18n !== 'undefined') print('i18nConfig = Object.assign(i18nConfig, JSON.parse(\''+JSON.stringify(config.i18n)+'\'));') %>
 
-  const mixinContext = require.context('@/', false, /^\.\/i18n\.js$/i);
+  const mixinContext = <%
+    const extensions = config.additionalExtensions.join('|');
+    print(`require.context('@/', false, /^\\.\\/i18n\\.(${extensions})$/i);`);
+  %>
   for (const r of mixinContext.keys()) {
     const mixin = mixinContext(r).default;
     if (typeof mixin !== 'undefined') {

--- a/packages/@averjs/vue-app/templates/store/index.js
+++ b/packages/@averjs/vue-app/templates/store/index.js
@@ -8,7 +8,10 @@ import merge from 'lodash/merge'
 Vue.use(Vuex);
 
 export function createStore(ssrContext) {
-  const files = require.context('@/', true, /vuex\/([^/]+)\.js$/i);
+  const files = <%
+    const extensions = config.additionalExtensions.join('|');
+    print(`require.context('@/', true, /vuex\\/([^/]+)\\.(${extensions})$/i);`);
+  %>
   const modules = {};
   const persistent = [];
   const plugins = [];
@@ -59,8 +62,10 @@ The following files have been ignored:${ignoreGlobalStoresList}.
 
   defaultConfig = { ...defaultConfig, modules, plugins };
   <% if (typeof config.store === 'object') print('defaultConfig = merge(defaultConfig, JSON.parse(\''+JSON.stringify(config.store)+'\'))'); %>
-
-  const mixinContext = require.context('@/', false, /^\.\/store\.js$/i);
+  
+  const mixinContext = <%
+    print(`require.context('@/', false, /^\\.\\/store\\.(${extensions})$/i);`);
+  %>
   for (const r of mixinContext.keys()) {
     const mixin = mixinContext(r).default;
     if (typeof mixin !== 'undefined') {
@@ -74,7 +79,9 @@ The following files have been ignored:${ignoreGlobalStoresList}.
   if (module.hot) {
     files.keys().map(path => files(path));
     module.hot.accept(files.id, () => {
-      const newFiles = require.context('@/', true, /vuex\/([^/]+)\.js$/i);
+      const newFiles = <%
+        print(`require.context('@/', true, /vuex\\/([^/]+)\\.(${extensions})$/i);`);
+      %>
       const newModules = {};
       let newConfig = {};
 


### PR DESCRIPTION
While this PR adds support for additional extensions, it only affects files compiled with webpack. This is also true for entries in plugins because they are getting copied inside the cache folder and can therefore have an extension which can be processed by the builder.