### PR TITLE
fix: concat missing global types

### DIFF
--- a/packages/@averjs/mailer/api-extractor.json
+++ b/packages/@averjs/mailer/api-extractor.json
@@ -3,5 +3,6 @@
   "mainEntryPointFilePath": "./dist/packages/@averjs/<unscopedPackageName>/lib/index.d.ts",
   "dtsRollup": {
     "publicTrimmedFilePath": "./dist/<unscopedPackageName>.d.ts"
+
   }
 }

--- a/packages/@averjs/mailer/lib/global.ts
+++ b/packages/@averjs/mailer/lib/global.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 import Email from 'email-templates';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* concat start */
 declare global {
   namespace Express {
     export interface Request {
@@ -18,3 +18,4 @@ declare global {
     }
   }
 }
+/* concat end */

--- a/packages/@averjs/mailer/lib/index.ts
+++ b/packages/@averjs/mailer/lib/index.ts
@@ -4,7 +4,6 @@ import path from 'path';
 import merge from 'lodash/merge';
 import { PluginFunction } from '@averjs/core/lib/plugins';
 import SMTPTransport from 'nodemailer/lib/smtp-transport';
-import './global';
 
 export interface MailerOptions {
   emailTemplatesConfig: EmailConfig;

--- a/packages/@averjs/websocket/lib/global.ts
+++ b/packages/@averjs/websocket/lib/global.ts
@@ -1,12 +1,14 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import { Server } from 'socket.io';
+/* concat start */
+import { Server as SocketIoServer } from 'socket.io';
 
 declare global {
   namespace Express {
     interface Request {
-      io: Server;
+      io: SocketIoServer;
     }
   }
 }
+/* concat end */
 
 export {};

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -124,6 +124,8 @@ export default class Build {
             fs.rmdirSync(path.resolve(pkg.path, './dist/packages'), {
               recursive: true
             });
+
+            this.appendGlobalTypes(pkg.path, pkg.pkg.types);
           }
 
           buildSpinner.succeed(`Built package ${pkg.pkg.name} successfully`);
@@ -132,6 +134,20 @@ export default class Build {
           throw error;
         }
       }
+    }
+  }
+
+  appendGlobalTypes(pkgPath: string, dtsFile = '') {
+    const globalPath = path.resolve(pkgPath, './lib/global.ts');
+    const dtsPath = path.resolve(pkgPath, dtsFile);
+
+    if (fs.existsSync(globalPath)) {
+      const globalTypes = fs.readFileSync(globalPath, 'utf-8');
+      const content = /\/\* concat start \*\/(?<content>(.|\n)*?)\/\* concat end \*\//.exec(
+        globalTypes
+      )?.groups?.content;
+      const dtsContent = fs.readFileSync(dtsPath, 'utf-8');
+      fs.writeFileSync(dtsPath, `${dtsContent}${content || ''}`, 'utf-8');
     }
   }
 }


### PR DESCRIPTION
api extractor currently removes global declared types so we need to concat them manually after every build